### PR TITLE
Add ClientDocs connector take-home challenge

### DIFF
--- a/connector/.gitignore
+++ b/connector/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/connector/candidate/BRIEF.md
+++ b/connector/candidate/BRIEF.md
@@ -1,0 +1,87 @@
+# ClientDocs Connector — Candidate Brief
+
+You're one of **our** forward-deployed engineers, working on our engagement with the
+client **MyClient**. MyClient runs an internal document system, **ClientDocs**, exposed over a REST API. Your job is to build a **connector** in a Python script that can:
+1. crawl ClientDocs and ingest them into **our Pipeline Service**
+2. crawl updates of documents, since the client may modify documents on a daily basis
+
+
+## The two APIs
+
+**Pipeline Service (ingestion)** ships with this project. Start it from the `connector`
+folder, in its own terminal:
+
+```bash
+./run_pipeline.sh
+```
+
+It serves at **http://localhost:8001/docs**.
+
+**ClientDocs (source)** is already running for you at **http://localhost:8002/docs**.
+
+The Swagger UI at `/docs` is the spec for each — read the endpoints and field descriptions there.
+
+## ClientDocs (source) — what you crawl
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /documents?page=&page_size=` | Paginated listing (`documents`, `page`, `page_size`, `total`). |
+| `GET /documents/{item_id}/content` | The document body (content) for an item, e.g. `DOC-0001`. |
+| `GET /documents/delta?since=<datetime>&page=&page_size=` | All document changes since a timestamp: `created`, `updated`, `deleted` events. |
+
+Each document has `item_id` and `uri` at the top level, plus `metadata` (`title`,
+`item_sensitivity`). The `uri` is dependent on the document's file path in ClientDocs.
+The body is **not** included; fetch it per item from `GET /documents/{item_id}/content`.
+
+In the delta, **every event (`created`, `updated` and `deleted`) carries `item_id` and `uri`**; `created`/`updated` also carry `metadata`.
+
+**Paging & incremental sync.** Both endpoints page with `page` / `page_size`. The full crawl
+returns the **current state** of every document; the delta takes a `since` datetime and
+returns whatever changed after it.
+
+
+## Pipeline Service (ingestion) — where you write
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /ingestion/documents/document-batches` | Upsert a batch of documents. |
+| `POST /ingestion/documents/delete-document-batches` | Delete a batch by `document_ids`. |
+| `GET /ingestion/documents` | List what you've ingested (to verify). |
+| `GET /ingestion/documents/{document_id}` | Read one back (to verify). |
+
+Ingestion document fields:
+- `document_id` (optional — when set, it **must be a UUID**; if omitted, the pipeline generates it as `uuid5(CLIENT_NAME, document_uri)`,
+- `document_uri`, `title`, `document_content`, `client_specific_metadata { item_id, item_sensitivity }`.
+The batch response is `{ succeeded, failed }`, e.g.:
+
+```json
+{
+  "succeeded": [{ "document_id": "3f2504e0-4f89-51d3-9a0c-0305e82c3301" }],
+  "failed": [
+    { "document_uri": "client://docs/legal/document-0002.pdf", "document_id": "not-a-uuid",
+      "error_code": "INVALID_DOCUMENT_ID", "error_message": "document_id must be a UUID" }
+  ]
+}
+```
+
+## Part 1 — Full crawl
+
+Full-crawl ClientDocs, fetch each document's content, and ingest every document into the
+pipeline.
+(This environment simulates a point in the past, so full crawl will give you all 
+documents until that point)
+
+## Part 2 — Delta crawl
+
+Consume `GET /documents/delta?since=<datetime>` to fetch what changed after your crawl —
+ingest the `created`/`updated` docs and **apply the `deleted` events**. Use
+**`since=2024-06-01T00:00:00`** (the crawl's point in time) to pick up everything that
+changed after it.
+
+## Part 3 — Discussion (no code)
+
+- **Scaling.** There are millions of documents in the ClientDocs side. How can you scale the ingestion?
+- **Fast sync.** The client wants updates synced very fast (e.g. within a minute). How would you approach it?
+- **Ingestion failures.** The pipeline may report that some docs failed to ingest — how would you handle it?
+- **Deletion failures.** The pipeline may report that a deletion failed — how would you handle it?
+

--- a/connector/pipeline_mock.py
+++ b/connector/pipeline_mock.py
@@ -1,0 +1,184 @@
+import uuid
+from typing import Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+app = FastAPI(
+    title="Pipeline Service - Self-Service Ingestion API (mock)",
+    version="1.0.0",
+    description="Ingest documents into the search index. Open /docs for the live spec.",
+)
+app.state.store = {}
+
+
+class ClientSpecificMetadata(BaseModel):
+    item_id: str
+    item_sensitivity: str  # public | internal | confidential
+
+
+class DocumentIngestionForm(BaseModel):
+    document_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional. When provided it MUST be a UUID (e.g. "
+            "`123e4567-e89b-12d3-a456-426614174000`); non-UUID values are rejected. If "
+            "omitted, the service generates it as `uuid5(CLIENT_NAME, document_uri)` — "
+            "namespaced by the client's name, `CLIENT_NAME = \"myclient\"` (precisely, the "
+            "namespace is `uuid5(NAMESPACE_DNS, CLIENT_NAME)`) — so ids are scoped per client "
+            "and deterministic from the uri. Send the same document_id on later "
+            "upserts/deletes to target the same document."
+        ),
+    )
+    document_uri: str = Field(
+        description=(
+            "Required. The document's URI — the natural key from which `document_id` is "
+            "derived when you omit `document_id`."
+        )
+    )
+    title: str = Field(description="Document title; embedded for search.")
+    document_content: str = Field(
+        description="Document body; embedded for search. Required — empty content is rejected (returned in `failed`)."
+    )
+    client_specific_metadata: Optional[ClientSpecificMetadata] = Field(
+        default=None,
+        description="Client-specific metadata stored with the document (e.g. the source item_id and sensitivity).",
+    )
+
+
+class DocumentBatch(BaseModel):
+    documents: List[DocumentIngestionForm]
+
+
+class DeleteDocumentBatch(BaseModel):
+    document_ids: List[str] = Field(
+        description=(
+            "Pipeline document_ids to delete. Deletion is by document_id only — the value "
+            "returned at ingest (or the one you supplied)."
+        )
+    )
+
+
+class IngestedDocument(BaseModel):
+    document_id: str
+    document_uri: str
+    title: str
+    document_content: str
+    client_specific_metadata: Optional[ClientSpecificMetadata] = None
+
+
+class IngestedDocumentSummary(BaseModel):
+    document_id: str
+    document_uri: str
+    title: str
+
+
+class SucceededDoc(BaseModel):
+    document_id: str = Field(
+        description="The stored document_id — the value you supplied, or the one generated from `document_uri` when omitted."
+    )
+
+
+class RejectedDoc(BaseModel):
+    document_uri: Optional[str] = None
+    document_id: Optional[str] = None
+    error_code: str = Field(description="e.g. EMPTY_CONTENT or INVALID_DOCUMENT_ID (ingest), NOT_FOUND (delete).")
+    error_message: str
+
+
+class BatchResponse(BaseModel):
+    succeeded: List[SucceededDoc] = Field(description="Documents ingested / upserted (or deleted).")
+    failed: List[RejectedDoc] = Field(description="Documents rejected — e.g. empty content or a non-UUID document_id on ingest, or NOT_FOUND on delete.")
+
+
+# document_ids are namespaced per client: each client has a unique name, so the same uri
+# under a different client yields a different id.
+CLIENT_NAME = "myclient"
+NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, CLIENT_NAME)
+
+
+def document_id_from_uri(document_uri: str) -> str:
+    return str(uuid.uuid5(NAMESPACE, document_uri))
+
+
+def is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+@app.post("/ingestion/documents/document-batches", response_model=BatchResponse)
+def create_document_batch(batch: DocumentBatch) -> BatchResponse:
+    succeeded: List[SucceededDoc] = []
+    failed: List[RejectedDoc] = []
+    for doc in batch.documents:
+        if not doc.document_content.strip():
+            failed.append(
+                RejectedDoc(
+                    document_uri=doc.document_uri,
+                    document_id=doc.document_id,
+                    error_code="EMPTY_CONTENT",
+                    error_message="document_content is empty; nothing to embed",
+                )
+            )
+            continue
+        if doc.document_id is not None and not is_uuid(doc.document_id):
+            failed.append(
+                RejectedDoc(
+                    document_uri=doc.document_uri,
+                    document_id=doc.document_id,
+                    error_code="INVALID_DOCUMENT_ID",
+                    error_message="document_id must be a UUID",
+                )
+            )
+            continue
+        document_id = doc.document_id or document_id_from_uri(doc.document_uri)
+        app.state.store[document_id] = IngestedDocument(
+            document_id=document_id,
+            document_uri=doc.document_uri,
+            title=doc.title,
+            document_content=doc.document_content,
+            client_specific_metadata=doc.client_specific_metadata,
+        )
+        succeeded.append(SucceededDoc(document_id=document_id))
+    return BatchResponse(succeeded=succeeded, failed=failed)
+
+
+@app.post("/ingestion/documents/delete-document-batches", response_model=BatchResponse)
+def delete_document_batch(batch: DeleteDocumentBatch) -> BatchResponse:
+    succeeded: List[SucceededDoc] = []
+    failed: List[RejectedDoc] = []
+    for document_id in batch.document_ids:
+        if document_id in app.state.store:
+            del app.state.store[document_id]
+            succeeded.append(SucceededDoc(document_id=document_id))
+        else:
+            failed.append(
+                RejectedDoc(
+                    document_id=document_id,
+                    error_code="NOT_FOUND",
+                    error_message="no document with this document_id",
+                )
+            )
+    return BatchResponse(succeeded=succeeded, failed=failed)
+
+
+@app.get("/ingestion/documents", response_model=List[IngestedDocumentSummary])
+def list_documents() -> List[IngestedDocumentSummary]:
+    return [
+        IngestedDocumentSummary(
+            document_id=doc.document_id,
+            document_uri=doc.document_uri,
+            title=doc.title,
+        )
+        for doc in app.state.store.values()
+    ]
+
+
+@app.get("/ingestion/documents/{document_id}", response_model=IngestedDocument)
+def get_document(document_id: str) -> IngestedDocument:
+    if document_id not in app.state.store:
+        raise HTTPException(status_code=404, detail="document not found")
+    return app.state.store[document_id]

--- a/connector/requirements.txt
+++ b/connector/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+httpx==0.27.2

--- a/connector/run_pipeline.sh
+++ b/connector/run_pipeline.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+python3 -m venv .venv 2>/dev/null || true
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+echo ""
+echo "Pipeline Service (ingestion) -> http://localhost:8001/docs"
+echo "Ctrl-C to stop."
+uvicorn pipeline_mock:app --port 8001

--- a/connector_client_servers/.gitignore
+++ b/connector_client_servers/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/connector_client_servers/clientdocs_mock.py
+++ b/connector_client_servers/clientdocs_mock.py
@@ -1,0 +1,145 @@
+from typing import List, Optional, Tuple
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+app = FastAPI(
+    title="ClientDocs API (mock)",
+    version="1.0.0",
+    description="The client source system. Open /docs for the live spec.",
+)
+
+DEPARTMENTS = ["finance", "legal", "engineering", "hr"]
+SENSITIVITIES = ["public", "internal", "confidential"]
+
+# This environment simulates "now" = 2024-06-01: the full crawl returns the current state of
+# every document as of then, and the changes below happened after it. (The interviewer tells
+# the candidate to run the delta with since=2024-06-01T00:00:00 to pick the updates up.)
+
+
+class DocumentMetadata(BaseModel):
+    title: str
+    item_sensitivity: str
+
+
+class Document(BaseModel):
+    item_id: str
+    uri: str = Field(description="The document's file path in ClientDocs (derived from where the file lives in the folder tree).")
+    metadata: DocumentMetadata
+
+
+class DocumentContent(BaseModel):
+    item_id: str
+    content: str
+
+
+def _dept(i: int) -> str:
+    return DEPARTMENTS[i % len(DEPARTMENTS)]
+
+
+def _uri(i: int) -> str:
+    return f"client://docs/{_dept(i)}/document-{i:04d}.pdf"
+
+
+def _meta(i: int, title: Optional[str] = None) -> DocumentMetadata:
+    return DocumentMetadata(
+        title=title or f"{_dept(i).capitalize()} Document {i}",
+        item_sensitivity=SENSITIVITIES[i % len(SENSITIVITIES)],
+    )
+
+
+def _doc(i: int) -> Document:
+    return Document(item_id=f"DOC-{i:04d}", uri=_uri(i), metadata=_meta(i))
+
+
+def _content(i: int) -> str:
+    return f"Body of {_dept(i)} document {i}. " * 8
+
+
+# Snapshot returned by the full crawl: documents 1..24.
+CRAWL = {f"DOC-{i:04d}": _doc(i) for i in range(1, 25)}
+
+# New documents created after the crawl.
+CREATED = {f"DOC-{i:04d}": _doc(i) for i in (25, 26)}
+
+# Body of every item that exists in the crawl snapshot + creations — served ONLY from
+# GET /documents/{item_id}/content. (Deletions are expressed through the delta feed, not
+# here; the content endpoint still serves a document that a later delta event deletes.)
+CONTENT = {f"DOC-{i:04d}": _content(i) for i in range(1, 27)}
+CONTENT["DOC-0003"] = "Body of hr document 3, revised. " * 8
+
+
+class DeltaEvent(BaseModel):
+    event_type: str = Field(description="One of: created | updated | deleted.")
+    item_id: str = Field(description="Canonical id of the changed document.")
+    uri: str = Field(description="The document's path — present on every event, including `deleted`.")
+    metadata: Optional[DocumentMetadata] = Field(
+        default=None,
+        description="Title + sensitivity — present on `created` and `updated` events (absent on `deleted`). The body is not included; fetch it from `/documents/{item_id}/content`.",
+    )
+
+
+# Changes since the 2024-06-01 crawl point, as (changed_at, event). The timestamp is
+# server-side only — used to honor `since` and to return the feed oldest-first — and is NOT
+# exposed on the event; a client advances its sync position by the time of each run.
+CHANGES: List[Tuple[str, DeltaEvent]] = [
+    ("2024-06-02T09:00:00", DeltaEvent(event_type="created", item_id="DOC-0025", uri=_uri(25), metadata=_meta(25))),
+    ("2024-06-02T09:05:00", DeltaEvent(event_type="created", item_id="DOC-0026", uri=_uri(26), metadata=_meta(26))),
+    ("2024-06-04T08:00:00", DeltaEvent(event_type="deleted", item_id="DOC-0005", uri=_uri(5))),
+    ("2024-06-05T14:00:00", DeltaEvent(event_type="updated", item_id="DOC-0003", uri=_uri(3), metadata=_meta(3, "Hr Document 3 (revised)"))),
+]
+
+
+class DocumentPage(BaseModel):
+    documents: List[Document]
+    page: int = Field(description="1-based page number of this response.")
+    page_size: int = Field(description="Documents per page.")
+    total: int = Field(description="Total documents in the listing. Keep paging while page * page_size < total.")
+
+
+class DeltaPage(BaseModel):
+    events: List[DeltaEvent]
+    page: int = Field(description="1-based page number of this response.")
+    page_size: int = Field(description="Events per page.")
+    total: int = Field(description="Total change events after `since`. Keep paging while page * page_size < total.")
+
+
+def _page(items: list, page: int, page_size: int) -> list:
+    start = (page - 1) * page_size
+    return items[start : start + page_size]
+
+
+@app.get("/documents", response_model=DocumentPage)
+def list_documents(
+    page: int = Query(1, ge=1, description="1-based page number. Start at 1 and increment until page * page_size >= total."),
+    page_size: int = Query(10, ge=1, description="Documents per page."),
+) -> DocumentPage:
+    items = list(CRAWL.values())
+    return DocumentPage(
+        documents=_page(items, page, page_size),
+        page=page,
+        page_size=page_size,
+        total=len(items),
+    )
+
+
+@app.get("/documents/delta", response_model=DeltaPage)
+def get_delta(
+    since: str = Query(..., description="Return changes strictly after this ISO-8601 datetime — the point in time your last sync covered (for the first delta, the moment of your full crawl)."),
+    page: int = Query(1, ge=1, description="1-based page number."),
+    page_size: int = Query(10, ge=1, description="Events per page."),
+) -> DeltaPage:
+    matching = [ev for ts, ev in sorted(CHANGES, key=lambda c: c[0]) if ts > since]
+    return DeltaPage(
+        events=_page(matching, page, page_size),
+        page=page,
+        page_size=page_size,
+        total=len(matching),
+    )
+
+
+@app.get("/documents/{item_id}/content", response_model=DocumentContent)
+def get_content(item_id: str) -> DocumentContent:
+    if item_id in CONTENT:
+        return DocumentContent(item_id=item_id, content=CONTENT[item_id])
+    raise HTTPException(status_code=404, detail="document not found")

--- a/connector_client_servers/clientdocs_prod.py
+++ b/connector_client_servers/clientdocs_prod.py
@@ -1,0 +1,167 @@
+# INTERVIEWER-ONLY — do NOT give this file to the candidate.
+#
+# Drop-in replacement for candidate/servers/clientdocs_mock.py: identical API and Swagger, but
+# the data is "production messy" where the happy-path mock is clean. Swap this in on port 8002
+# to see whether the candidate's connector — built against the tidy mock — survives reality.
+#
+# What's harder here than in the mock:
+#
+#   Delta feed (Part 2) — the change log repeats items: DOC-0003 changes twice and DOC-0011
+#     is updated after having been deleted. Like the mock it's returned oldest-first, so a
+#     straight in-order apply lands on the CORRECT end state (DOC-0003 -> "revised", DOC-0011
+#     -> present) — but it does redundant work: DOC-0003 is upserted twice, and DOC-0011 is
+#     deleted and then re-created (a wasted round-trip and a transient window where it's gone).
+#     Collapsing to one op per item_id is the OPTIMIZATION; the mock's delta has one event per
+#     item, so a candidate has no reason to reach for it there. This is not a correctness trap.
+#
+#   Content endpoint (Part 1) — the real correctness traps; two crawl documents misbehave:
+#     - DOC-0007 — EMPTY content. The endpoint returns "" → the pipeline rejects it in
+#       `failed` (EMPTY_CONTENT); a connector that ignores the failed list loses it silently.
+#     - DOC-0013 — NO content. The endpoint 404s → the per-item content fetch fails and the
+#       connector has to cope instead of crashing.
+#
+# Run it in place of clientdocs_mock:
+#
+#   uvicorn clientdocs_prod:app --port 8002
+
+from typing import List, Optional, Tuple
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+app = FastAPI(
+    title="ClientDocs API (mock)",
+    version="1.0.0",
+    description="The client source system. Open /docs for the live spec.",
+)
+
+DEPARTMENTS = ["finance", "legal", "engineering", "hr"]
+SENSITIVITIES = ["public", "internal", "confidential"]
+
+
+class DocumentMetadata(BaseModel):
+    title: str
+    item_sensitivity: str
+
+
+class Document(BaseModel):
+    item_id: str
+    uri: str = Field(description="The document's file path in ClientDocs (derived from where the file lives in the folder tree).")
+    metadata: DocumentMetadata
+
+
+class DocumentContent(BaseModel):
+    item_id: str
+    content: str
+
+
+def _dept(i: int) -> str:
+    return DEPARTMENTS[i % len(DEPARTMENTS)]
+
+
+def _uri(i: int) -> str:
+    return f"client://docs/{_dept(i)}/document-{i:04d}.pdf"
+
+
+def _meta(i: int, title: Optional[str] = None) -> DocumentMetadata:
+    return DocumentMetadata(
+        title=title or f"{_dept(i).capitalize()} Document {i}",
+        item_sensitivity=SENSITIVITIES[i % len(SENSITIVITIES)],
+    )
+
+
+def _doc(i: int) -> Document:
+    return Document(item_id=f"DOC-{i:04d}", uri=_uri(i), metadata=_meta(i))
+
+
+def _content(i: int) -> str:
+    # DOC-0007 has an empty body -> the pipeline rejects it (EMPTY_CONTENT).
+    return "" if i == 7 else f"Body of {_dept(i)} document {i}. " * 8
+
+
+CRAWL = {f"DOC-{i:04d}": _doc(i) for i in range(1, 25)}
+CREATED = {f"DOC-{i:04d}": _doc(i) for i in (25, 26)}
+
+CONTENT = {f"DOC-{i:04d}": _content(i) for i in range(1, 27)}
+CONTENT["DOC-0003"] = "Body of hr document 3, revised. " * 8
+# DOC-0013 has NO content at the source: the content endpoint 404s, so the connector's
+# per-item content fetch fails and it must handle that.
+del CONTENT["DOC-0013"]
+
+
+class DeltaEvent(BaseModel):
+    event_type: str = Field(description="One of: created | updated | deleted.")
+    item_id: str = Field(description="Canonical id of the changed document.")
+    uri: str = Field(description="The document's path — present on every event, including `deleted`.")
+    metadata: Optional[DocumentMetadata] = Field(
+        default=None,
+        description="Title + sensitivity — present on `created` and `updated` events (absent on `deleted`). The body is not included; fetch it from `/documents/{item_id}/content`.",
+    )
+
+
+# (changed_at, event); returned oldest-first, timestamp server-side only (see clientdocs_mock).
+# Repeats: DOC-0003 changed twice, DOC-0011 deleted @06-02 then updated @06-06.
+CHANGES: List[Tuple[str, DeltaEvent]] = [
+    ("2024-06-02T09:00:00", DeltaEvent(event_type="created", item_id="DOC-0025", uri=_uri(25), metadata=_meta(25))),
+    ("2024-06-05T14:00:00", DeltaEvent(event_type="updated", item_id="DOC-0003", uri=_uri(3), metadata=_meta(3, "Hr Document 3 (revised)"))),
+    ("2024-06-06T08:00:00", DeltaEvent(event_type="updated", item_id="DOC-0011", uri=_uri(11), metadata=_meta(11))),
+    ("2024-06-02T09:05:00", DeltaEvent(event_type="created", item_id="DOC-0026", uri=_uri(26), metadata=_meta(26))),
+    ("2024-06-04T08:00:00", DeltaEvent(event_type="deleted", item_id="DOC-0005", uri=_uri(5))),
+    ("2024-06-03T10:00:00", DeltaEvent(event_type="updated", item_id="DOC-0003", uri=_uri(3), metadata=_meta(3, "Hr Document 3 (rev)"))),
+    ("2024-06-02T07:00:00", DeltaEvent(event_type="deleted", item_id="DOC-0011", uri=_uri(11))),
+]
+
+
+class DocumentPage(BaseModel):
+    documents: List[Document]
+    page: int = Field(description="1-based page number of this response.")
+    page_size: int = Field(description="Documents per page.")
+    total: int = Field(description="Total documents in the listing. Keep paging while page * page_size < total.")
+
+
+class DeltaPage(BaseModel):
+    events: List[DeltaEvent]
+    page: int = Field(description="1-based page number of this response.")
+    page_size: int = Field(description="Events per page.")
+    total: int = Field(description="Total change events after `since`. Keep paging while page * page_size < total.")
+
+
+def _page(items: list, page: int, page_size: int) -> list:
+    start = (page - 1) * page_size
+    return items[start : start + page_size]
+
+
+@app.get("/documents", response_model=DocumentPage)
+def list_documents(
+    page: int = Query(1, ge=1, description="1-based page number. Start at 1 and increment until page * page_size >= total."),
+    page_size: int = Query(10, ge=1, description="Documents per page."),
+) -> DocumentPage:
+    items = list(CRAWL.values())
+    return DocumentPage(
+        documents=_page(items, page, page_size),
+        page=page,
+        page_size=page_size,
+        total=len(items),
+    )
+
+
+@app.get("/documents/delta", response_model=DeltaPage)
+def get_delta(
+    since: str = Query(..., description="Return changes strictly after this ISO-8601 datetime — the point in time your last sync covered (for the first delta, the moment of your full crawl)."),
+    page: int = Query(1, ge=1, description="1-based page number."),
+    page_size: int = Query(10, ge=1, description="Events per page."),
+) -> DeltaPage:
+    matching = [ev for ts, ev in sorted(CHANGES, key=lambda c: c[0]) if ts > since]
+    return DeltaPage(
+        events=_page(matching, page, page_size),
+        page=page,
+        page_size=page_size,
+        total=len(matching),
+    )
+
+
+@app.get("/documents/{item_id}/content", response_model=DocumentContent)
+def get_content(item_id: str) -> DocumentContent:
+    if item_id in CONTENT:
+        return DocumentContent(item_id=item_id, content=CONTENT[item_id])
+    raise HTTPException(status_code=404, detail="document not found")

--- a/connector_client_servers/requirements.txt
+++ b/connector_client_servers/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+httpx==0.27.2

--- a/connector_client_servers/run_client_mock.sh
+++ b/connector_client_servers/run_client_mock.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+python3 -m venv .venv 2>/dev/null || true
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+echo ""
+echo "ClientDocs source API (mock) -> http://localhost:8002/docs"
+echo "Ctrl-C to stop."
+uvicorn clientdocs_mock:app --port 8002

--- a/connector_client_servers/run_client_prod.sh
+++ b/connector_client_servers/run_client_prod.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+python3 -m venv .venv 2>/dev/null || true
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+echo ""
+echo "ClientDocs source API (prod) -> http://localhost:8002/docs"
+echo "Ctrl-C to stop."
+uvicorn clientdocs_prod:app --port 8002


### PR DESCRIPTION
Adds the ClientDocs connector take-home challenge as two top-level folders.

- **`connector/`** — the candidate workspace (opened in the IDE): `candidate/BRIEF.md` (the task), the Pipeline Service mock (`pipeline_mock.py`), `run_pipeline.sh` to start it at `:8001`, and `requirements.txt`.
- **`connector_client_servers/`** — the ClientDocs source: `clientdocs_mock.py` (happy path) and `clientdocs_prod.py`, started via `run_client_mock.sh` / `run_client_prod.sh` at `:8002`.

The candidate builds a connector that full-crawls ClientDocs and ingests into the Pipeline Service (Part 1), then consumes the delta feed (Part 2), plus a short discussion (Part 3).